### PR TITLE
Fix NameError when loading a mirroritem

### DIFF
--- a/examples/example_library.py
+++ b/examples/example_library.py
@@ -19,5 +19,4 @@ from studioqt import QtWidgets
 if __name__ == "__main__":
 
     with studioqt.app():
-        path = "C:/Users/Hovel/Dropbox/libraries"
-        library = studiolibrary.main("Hello", path=path, lockFolder="Malcolm")
+        library = studiolibrary.main("Hello", lockFolder="Malcolm")

--- a/examples/example_library2.py
+++ b/examples/example_library2.py
@@ -17,5 +17,4 @@ logger = logging.getLogger("test_library")
 if __name__ == "__main__":
 
     with studioqt.app():
-        path = "C:/Users/Hovel/Dropbox/libraries"
-        studiolibrary.main(u"Exён Шple", path=path)
+        studiolibrary.main(u"Exён Шple")

--- a/src/studiolibrary/packages/studiolibraryitems/animitem.py
+++ b/src/studiolibrary/packages/studiolibraryitems/animitem.py
@@ -72,8 +72,10 @@ except ImportError, e:
 
 
 __all__ = [
-    "AnimationItem",
-    "AnimationItemError",
+    "AnimItem",
+    "AnimItemError",
+    "AnimCreateWidget",
+    "AnimPreviewWidget",
 ]
 
 logger = logging.getLogger(__name__)

--- a/src/studiolibrary/packages/studiolibraryitems/mirroritem.py
+++ b/src/studiolibrary/packages/studiolibraryitems/mirroritem.py
@@ -48,6 +48,7 @@ import logging
 from functools import partial
 
 # studioqt supports both pyside (Qt4) and pyside2 (Qt5)
+import studioqt
 from studioqt import QtGui
 from studioqt import QtCore
 from studioqt import QtWidgets
@@ -64,8 +65,13 @@ except ImportError, e:
     print e
 
 
-logger = logging.getLogger(__name__)
+__all__ = [
+    "MirrorItem",
+    "MirrorCreateWidget",
+    "MirrorPreviewWidget",
+]
 
+logger = logging.getLogger(__name__)
 
 MirrorOption = mutils.MirrorOption
 

--- a/src/studiolibrary/packages/studiolibraryitems/setsitem.py
+++ b/src/studiolibrary/packages/studiolibraryitems/setsitem.py
@@ -29,6 +29,12 @@ import studiolibraryitems
 from studiolibraryitems import transferitem
 
 
+__all__ = [
+    "SetsItem",
+    "SetsCreateWidget",
+    "SetsPreviewWidget",
+]
+
 class SetsItem(transferitem.TransferItem):
 
     @classmethod


### PR DESCRIPTION
- Remove the hardcoded path in the examples
- Fix the animitem __all__ var to the correct method names