### PR TITLE
Add support for the prefix and suffix naming conventions in mirrortables

### DIFF
--- a/src/studiolibrary/packages/mutils/mirrortable.py
+++ b/src/studiolibrary/packages/mutils/mirrortable.py
@@ -583,7 +583,7 @@ class MirrorTable(mutils.SelectionSet):
         if ":" in name:
             dstName = name.replace(":" + search, ":" + replace)
             if name != dstName:
-                return True
+                return dstName
 
         # Support for the prefix with long names
         # Group|LfootRollExtra|LfootRoll


### PR DESCRIPTION
@cgzoso 

Use the "*" character when you need to specify the prefix or suffix naming for the mirror table side.

Example:

"*_L" is the suffix naming convention.

"L_*" is the prefix naming convention.