### PR TITLE
Change the import order of shiboken

### DIFF
--- a/src/studiolibrary/gui/mayadockwidgetmixin.py
+++ b/src/studiolibrary/gui/mayadockwidgetmixin.py
@@ -23,15 +23,14 @@ try:
 except ImportError:
     isMaya = False
 
-try:
-    from shiboken import wrapInstance
-except Exception, msg:
-    print msg
 
 try:
     from shiboken2 import wrapInstance
-except Exception, msg:
-    print msg
+except ImportError:
+    try:
+        from shiboken import wrapInstance
+    except ImportError, e:
+        print e
 
 
 __all__ = [

--- a/src/studiolibrary/packages/mutils/gui/__init__.py
+++ b/src/studiolibrary/packages/mutils/gui/__init__.py
@@ -16,14 +16,17 @@
 
 import maya.OpenMayaUI as omui
 
-from studioqt import QtGui
-from studioqt import QtCore
 from studioqt import QtWidgets
 
+
 try:
-    from shiboken import wrapInstance
-except Exception:
     from shiboken2 import wrapInstance
+except ImportError:
+    try:
+        from shiboken import wrapInstance
+    except ImportError, e:
+        print e
+
 
 from .framerangemenu import FrameRangeMenu
 from .framerangemenu import showFrameRangeMenu


### PR DESCRIPTION
Remove "No module named shiboken" message when loading from Maya