### PR TITLE
Fix the mayadockwidgetmixin not working outside of maya

### DIFF
--- a/src/studiolibrary/packages/studiolibrarymaya/mayadockwidgetmixin.py
+++ b/src/studiolibrary/packages/studiolibrarymaya/mayadockwidgetmixin.py
@@ -171,18 +171,21 @@ class MayaDockWidgetMixin(object):
 
     def mayaWindow(self):
         """
-        :rtype: QMainWindow
+        :rtype: QMainWindow or None
         """
-        mainWindowPtr = omui.MQtUtil.mainWindow()
-        return wrapInstance(long(mainWindowPtr), QtWidgets.QMainWindow)
+        try:
+            mainWindowPtr = omui.MQtUtil.mainWindow()
+            return wrapInstance(long(mainWindowPtr), QtWidgets.QMainWindow)
+        except NameError, e:
+            logger.exception(e)
 
     def mapDockAreaToStr(self, dockArea):
         """
         :type dockArea: QtCore.Qt.QDockArea
         :rtype: str
         """
-        map = self.dockAreaMap()
-        return map[dockArea]
+        areaMap = self.dockAreaMap()
+        return areaMap[dockArea]
 
     def mapDockAreaFromStr(self, dockAreaStr):
         """
@@ -196,9 +199,9 @@ class MayaDockWidgetMixin(object):
         """
         :rtype: QtCore.Qt.DockWidgetAreas
         """
-        if self.isFloating():
-            dockArea = QtCore.Qt.NoDockWidgetArea
-        else:
+        dockArea = QtCore.Qt.NoDockWidgetArea
+
+        if self.mayaWindow() and not self.isFloating():
             dockArea = self.mayaWindow().dockWidgetArea(self.dockWidget())
         
         return dockArea

--- a/src/studiolibrary/packages/studiolibrarymaya/resource/ui/AnimPreviewWidget.ui
+++ b/src/studiolibrary/packages/studiolibrarymaya/resource/ui/AnimPreviewWidget.ui
@@ -292,7 +292,7 @@ QPushButton:!Checked {
                  </size>
                 </property>
                 <property name="toolTip">
-                 <string>Take snapshot</string>
+                 <string/>
                 </property>
                 <property name="layoutDirection">
                  <enum>Qt::LeftToRight</enum>

--- a/src/studiolibrary/packages/studiolibrarymaya/resource/ui/MirrorPreviewWidget.ui
+++ b/src/studiolibrary/packages/studiolibrarymaya/resource/ui/MirrorPreviewWidget.ui
@@ -283,7 +283,7 @@ QPushButton:!Checked {
                  </size>
                 </property>
                 <property name="toolTip">
-                 <string>Take snapshot</string>
+                 <string/>
                 </property>
                 <property name="layoutDirection">
                  <enum>Qt::LeftToRight</enum>

--- a/src/studiolibrary/packages/studiolibrarymaya/resource/ui/PosePreviewWidget.ui
+++ b/src/studiolibrary/packages/studiolibrarymaya/resource/ui/PosePreviewWidget.ui
@@ -286,7 +286,7 @@ QPushButton:!Checked {
                  </size>
                 </property>
                 <property name="toolTip">
-                 <string>Take snapshot</string>
+                 <string/>
                 </property>
                 <property name="layoutDirection">
                  <enum>Qt::LeftToRight</enum>

--- a/src/studiolibrary/packages/studiolibrarymaya/resource/ui/SetsPreviewWidget.ui
+++ b/src/studiolibrary/packages/studiolibrarymaya/resource/ui/SetsPreviewWidget.ui
@@ -283,7 +283,7 @@ QPushButton:!Checked {
                  </size>
                 </property>
                 <property name="toolTip">
-                 <string>Take snapshot</string>
+                 <string/>
                 </property>
                 <property name="layoutDirection">
                  <enum>Qt::LeftToRight</enum>


### PR DESCRIPTION
Remove "Take snapshot" annotation from the preview icon