### PR TITLE
Fix the root path for example1 and example2

### DIFF
--- a/docs/examples/example1.py
+++ b/docs/examples/example1.py
@@ -1,7 +1,5 @@
 # An example for creating a simple image library
 
-import os
-
 import studiolibrary
 
 # studioqt supports both pyside (Qt4) and pyside2 (Qt5)
@@ -61,6 +59,7 @@ class ImagePreviewWidget(QtWidgets.QWidget):
         self._image.setAlignment(QtCore.Qt.AlignHCenter)
 
         self._loadButton = QtWidgets.QPushButton("Load")
+        self._loadButton.setObjectName("acceptButton")
         self._loadButton.setFixedHeight(40)
         self._loadButton.clicked.connect(self.load)
 
@@ -93,13 +92,13 @@ def main():
     # Register the item class to be shown for the valid path extensions
     studiolibrary.registerItem(ImageItem)
 
-    studiolibrary.main(name="Image Library", path="data")
+    studiolibrary.main(name="Example1", path="data")
 
 
 if __name__ == "__main__":
 
     import studioqt
 
-    # Use the studioqt.app context to run a QApplication instance.
+    # Use the studioqt.app context to create and run a QApplication instance.
     with studioqt.app():
         main()

--- a/docs/examples/example2.py
+++ b/docs/examples/example2.py
@@ -25,7 +25,12 @@ if __name__ == "__main__":
 
     import studioqt
 
-    # Use the studioqt.app context to run a QApplication instance.
+    # Use the studioqt.app context to create and run a QApplication instance.
     with studioqt.app():
-        libraryWidget = CustomLibraryWidget.instance()
+
+        libraryWidget = CustomLibraryWidget.instance(
+            name="Example2",
+            path="data"
+        )
+
         libraryWidget.show()

--- a/docs/examples/example3.py
+++ b/docs/examples/example3.py
@@ -1,0 +1,18 @@
+# An example for how to lock specific folders using the lockRegExp param
+
+import studiolibrary
+
+
+if __name__ == "__main__":
+
+    import studioqt
+
+    # Use the studioqt.app context to create and run a QApplication instance.
+    with studioqt.app():
+
+        # Lock all folders that contain the words "icon" & "Pixar" in the path.
+        studiolibrary.main(
+            name="Example3",
+            path="data",
+            lockRegExp="icon|Pixar",
+        )

--- a/librarywidget.py
+++ b/librarywidget.py
@@ -87,13 +87,28 @@ class LibraryWidget(QtWidgets.QWidget):
         return cls._instances.values()
 
     @classmethod
-    def instance(cls, name=None, path=None):
+    def instance(
+            cls,
+            name=None,
+            path=None,
+            show=False,
+            lock=False,
+            superusers=None,
+            lockRegExp=None,
+            unlockRegExp=None,
+    ):
         """
         Return the library widget for the given path.
 
         :type name: str
         :type path: str
-        :rtype: CatalogWidget
+        :type show: bool
+        :type lock: bool
+        :type superusers: list[str]
+        :type lockRegExp: str
+        :type unlockRegExp: str
+        
+        :rtype: LibraryWidget
         """
         name = name or cls.DEFAULT_NAME
 
@@ -108,9 +123,22 @@ class LibraryWidget(QtWidgets.QWidget):
             if mutils.isMaya():
                 mutils.gui.makeMayaStandaloneWindow(w)
 
+        w.setLocked(lock)
+        w.setSuperusers(superusers)
+        w.setLockRegExp(lockRegExp)
+        w.setUnlockRegExp(unlockRegExp)
+
+        if show:
+            w.show()
+
         return w
 
-    def __init__(self, parent=None, name=None, path=None):
+    def __init__(
+            self,
+            parent=None,
+            name=None,
+            path=None,
+    ):
         """
         Return the a new instance of the Library Widget.
 

--- a/main.py
+++ b/main.py
@@ -15,46 +15,47 @@ import studiolibrary
 
 
 def main(
+        cls=None,
         name=None,
         path=None,
         show=True,
         lock=False,
         superusers=None,
-        lockFolder=None,
-        unlockFolder=None,
+        lockRegExp=None,
+        unlockRegExp=None,
 ):
     """
-    The main entry point for creating and loading a library.
+    Convenience method for creating and loading a library widget instance.
 
-    This is a convenience method.
-
+    :type cls: studiolibrary.LibraryWidget.__class__
     :type name: str or None
     :type path: str or None
     :type show: bool
     :type lock: bool
-    :type superusers: str
-    :type lockFolder: str
-    :type unlockFolder: str
+    :type superusers: list[str]
+    :type lockRegExp: str
+    :type unlockRegExp: str
 
     :rtype: studiolibrary.LibraryWidget
     """
-    cls = studiolibrary.LIBRARY_WIDGET_CLASS or studiolibrary.LibraryWidget
+    cls = cls \
+        or studiolibrary.LIBRARY_WIDGET_CLASS \
+        or studiolibrary.LibraryWidget
 
-    libraryWidget = cls.instance(name, path)
-
-    libraryWidget.setLocked(lock)
-    libraryWidget.setSuperusers(superusers)
-    libraryWidget.setLockRegExp(lockFolder)
-    libraryWidget.setUnlockRegExp(unlockFolder)
-
-    if show:
-        libraryWidget.show()
+    libraryWidget = cls.instance(
+        name,
+        path,
+        show=show,
+        lock=lock,
+        superusers=superusers,
+        lockRegExp=lockRegExp,
+        unlockRegExp=unlockRegExp,
+    )
 
     return libraryWidget
 
 
 if __name__ == "__main__":
-
     import logging
     import studioqt
 

--- a/packages/studioqt/resource/css/default.css
+++ b/packages/studioqt/resource/css/default.css
@@ -63,10 +63,17 @@ QPushButton#updateButton {
     background-color: rgb(FOREGROUND_COLOR_R, FOREGROUND_COLOR_G, FOREGROUND_COLOR_B, 220);
 }
 
-QPushButton#updateButton:hover {
-    background-color: rgb(FOREGROUND_COLOR_R, FOREGROUND_COLOR_G, FOREGROUND_COLOR_B, 255);
+
+QPushButton#acceptButton {
+	font: bold 12*DPIpx;
+	color: FOREGROUND_COLOR;
+    background-color: rgb(ACCENT_COLOR_R, ACCENT_COLOR_G, ACCENT_COLOR_B, 230);
 }
 
+QPushButton#acceptButton:hover {
+	color: FOREGROUND_COLOR;
+    background-color: ACCENT_COLOR;
+}
 
 /*
  --------------------------------------------------------------------------


### PR DESCRIPTION
Add support for passing a library widget class to the studiolibrary.main
Move the studiolibrary.main arguments to the LibraryWidget class method
Rename the arguments "lockFolder" and "unlockFolder" to "lockRegExp" and "unlockRegExp"