### PR TITLE
Support proxy attributes.

### DIFF
--- a/packages/mutils/animation.py
+++ b/packages/mutils/animation.py
@@ -596,6 +596,10 @@ class Animation(mutils.Pose):
                         fullname = ("%s.%s" % (transform, attr))
                         dstCurve, = maya.cmds.listConnections(fullname, destination=False) or [None]
 
+                        # Filter to only animCurves since you can have proxy attributes
+                        if not maya.cmds.nodeType(dstCurve).startswith("animCurve"):
+                            continue
+
                         if dstCurve:
                             dstCurve = maya.cmds.rename(dstCurve, "CURVE")
                             srcCurve = mutils.animCurve("%s.%s" % (name, attr))

--- a/packages/mutils/animation.py
+++ b/packages/mutils/animation.py
@@ -596,11 +596,11 @@ class Animation(mutils.Pose):
                         fullname = ("%s.%s" % (transform, attr))
                         dstCurve, = maya.cmds.listConnections(fullname, destination=False) or [None]
 
-                        # Filter to only animCurves since you can have proxy attributes
-                        if not maya.cmds.nodeType(dstCurve).startswith("animCurve"):
-                            continue
-
                         if dstCurve:
+                            # Filter to only animCurves since you can have proxy attributes
+                            if not maya.cmds.nodeType(dstCurve).startswith("animCurve"):
+                                continue
+
                             dstCurve = maya.cmds.rename(dstCurve, "CURVE")
                             srcCurve = mutils.animCurve("%s.%s" % (name, attr))
                             if srcCurve and "animCurve" in maya.cmds.nodeType(srcCurve):


### PR DESCRIPTION
The issue we were facing was that we were using proxy attributes to clone an attribute to multiple controls. When exporting the animation the code wanted to rename a referenced controller.

Filter to animCurves only when exporting animation, to support proxy attributes.

Here is the code to make proxy attributes: http://www.cultofrig.com/2017/07/23/pilot-season-day-17-maya-assets-encapsulation/