### PR TITLE
added .gitattributes to ignore ma files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+packages/mutils/tests/data/* linguist-vendored


### PR DESCRIPTION
Right now github is looking at the .ma files in the tests folder and thinking the project primary language is `mathematica`

![screen shot 2018-03-08 at 2 21 33 pm](https://user-images.githubusercontent.com/2767425/37141868-71eafc54-22dc-11e8-9683-7c3ad1dc3d2f.png)

Added the .gitattributes file to fix that.

![screen shot 2018-03-08 at 2 21 59 pm](https://user-images.githubusercontent.com/2767425/37141878-77725a8c-22dc-11e8-9838-9ebd02f41f76.png)

Hope that helps! Thanks 🙂 