### PR TITLE
Fix "Show in Folder" outside KDE

### DIFF
--- a/cmds.py
+++ b/cmds.py
@@ -1107,7 +1107,7 @@ def showInFolder(path):
         args = [unicode(SHOW_IN_FOLDER_CMD)]
 
     elif isLinux():
-        args = [u'konqueror "{path}"&']
+        args = [u'xdg-open "{path}"&']
 
     elif isWindows():
         # os.system() and subprocess.call() can't pass command with


### PR DESCRIPTION
Show in Folder was hardcoded to konqueror which may not be available in gnome, xfce etc. xdg-open will delegate to the appropriate file browser for that DE/user preference