### PR TITLE
Adding more display options, adding variables and methodes to ease overrides.

### DIFF
--- a/src/studiolibrary/library.py
+++ b/src/studiolibrary/library.py
@@ -184,9 +184,22 @@ class Library(QtCore.QObject):
 
             data[path] = itemData
 
+        self.postSync(data)
+
         self.save(data)
 
         self.dataChanged.emit()
+
+
+    def postSync(self, data):
+        """
+        Use this function to execute code on the data after sync, but before save and dataChanged.emit
+
+        :type data: dict
+        :rtype: None
+        """
+        pass
+
 
     def findItems(self, queries, libraryWidget=None):
         """
@@ -255,6 +268,9 @@ class Library(QtCore.QObject):
 
                     elif cond == 'is':
                         match = value == itemValue
+
+                    elif cond == 'not':
+                        match = value != itemValue
 
                     elif cond == 'startswith':
                         match = itemValue.startswith(value)

--- a/src/studiolibrary/libraryitem.py
+++ b/src/studiolibrary/libraryitem.py
@@ -291,6 +291,11 @@ class LibraryItem(studioqt.Item):
         action.triggered.connect(self.showInFolder)
         menu.addAction(action)
 
+        if self.libraryWidget():
+            action = QtWidgets.QAction("Select Folder", menu)
+            action.triggered.connect(self.selectFolder)
+            menu.addAction(action)
+
     def contextMenu(self, menu, items=None):
         """
         Called when the user right clicks on the item.
@@ -305,6 +310,12 @@ class LibraryItem(studioqt.Item):
         """Open the file explorer at the given path location."""
         path = self.path()
         studiolibrary.showInFolder(path)
+
+    def selectFolder(self):
+        """select the folder in the library widget"""
+        if self.libraryWidget():
+            path = '/'.join(studiolibrary.normPath(self.path()).split('/')[:-1])
+            self.libraryWidget().selectFolderPath(path)
 
     def url(self):
         """Used by the mime data when dragging/dropping the item."""

--- a/src/studiolibrary/librarywidget.py
+++ b/src/studiolibrary/librarywidget.py
@@ -508,6 +508,9 @@ class LibraryWidget(QtWidgets.QWidget):
         library = self.createLibrary()
         self.setLibrary(library)
 
+        if not os.path.exists(library.databasePath()):
+            library.sync()
+
         self.refresh()
 
     @studioqt.showArrowCursor


### PR DESCRIPTION
Hi Kurt,

First, thank you a lot for this awesome library !  We are looking to use it internally, and I wanted to make sure we could easily merge back any changes from the original implementation.
So I'm only creating custom classes inheriting from yours and I was missing a few options to easily replace your widgets by mine.

1. I've added the class variable on the LibraryWidget, so they can be replaced easily.

    ITEMSWIDGETCLASSTYPE = studioqt.ItemsWidget
    SEARCHWIDGETCLASSTYPE = studioqt.SearchWidget
    STATUSWIDGETCLASSTYPE = studioqt.StatusWidget
    MENUBARWIDGETCLASSTYPE = studioqt.MenuBarWidget
    SIDEBARWIDGETCLASSTYPE = studioqt.SidebarWidget

2. I've encountered a small bug when reloading my own classes as the LibraryWidgets.destroyInstances was replacing the _instances by a list instead of a dictionary.

3. Our library is fairly big and with a lot of sub folders.  I've added an option to hide Folders in the LibraryWidget.  I think this might be useful for other people too.

4. I've added a 'Select Folder' on the LibraryItem 'Edit' menu.  This allows to select the folder containing the Item.

5. I've added a postSync method on the Library to be executed at the end of the sync but before the save and emit.  By default it does nothing, but for us it allows us to execute a few internal command on the library before displaying it.

6. I've added the 'not' filter condition.

I hope all this make sense.

Cheers,
Jerome.