### PR TITLE
Exposing the LIBRARY_CLASS in the LibraryWindow.

### DIFF
--- a/src/studiolibrary/libraryitem.py
+++ b/src/studiolibrary/libraryitem.py
@@ -294,9 +294,10 @@ class LibraryItem(studiolibrary.widgets.Item):
         action.triggered.connect(self.showInFolder)
         menu.addAction(action)
 
-        action = QtWidgets.QAction("Select Folder", menu)
-        action.triggered.connect(self.selectFolder)
-        menu.addAction(action)
+        if self.libraryWindow():
+            action = QtWidgets.QAction("Select Folder", menu)
+            action.triggered.connect(self.selectFolder)
+            menu.addAction(action)
 
     def contextMenu(self, menu, items=None):
         """
@@ -315,13 +316,9 @@ class LibraryItem(studiolibrary.widgets.Item):
 
     def selectFolder(self):
         """select the folder in the library widget"""
-        #get the main window:
-        window = self.treeWidget()
-        while window != None and not isinstance( window, studiolibrary.librarywindow.LibraryWindow ):
-            window = window.parent()
-        if window != None:
+        if self.libraryWindow():
             path = '/'.join(studiolibrary.normPath(self.path()).split('/')[:-1])
-            window.selectFolderPath(path)
+            self.libraryWindow().selectFolderPath(path)
 
     def url(self):
         """Used by the mime data when dragging/dropping the item."""

--- a/src/studiolibrary/libraryitem.py
+++ b/src/studiolibrary/libraryitem.py
@@ -16,6 +16,7 @@ from functools import partial
 
 import studiolibrary
 import studiolibrary.widgets
+import studiolibrary.librarywindow
 
 import studioqt
 
@@ -293,10 +294,9 @@ class LibraryItem(studiolibrary.widgets.Item):
         action.triggered.connect(self.showInFolder)
         menu.addAction(action)
 
-        if self.libraryWindow():
-            action = QtWidgets.QAction("Select Folder", menu)
-            action.triggered.connect(self.selectFolder)
-            menu.addAction(action)
+        action = QtWidgets.QAction("Select Folder", menu)
+        action.triggered.connect(self.selectFolder)
+        menu.addAction(action)
 
     def contextMenu(self, menu, items=None):
         """
@@ -315,9 +315,13 @@ class LibraryItem(studiolibrary.widgets.Item):
 
     def selectFolder(self):
         """select the folder in the library widget"""
-        if self.libraryWindow():
+        #get the main window:
+        window = self.treeWidget()
+        while window != None and not isinstance( window, studiolibrary.librarywindow.LibraryWindow ):
+            window = window.parent()
+        if window != None:
             path = '/'.join(studiolibrary.normPath(self.path()).split('/')[:-1])
-            self.libraryWindow().selectFolderPath(path)
+            window.selectFolderPath(path)
 
     def url(self):
         """Used by the mime data when dragging/dropping the item."""

--- a/src/studiolibrary/librarywindow.py
+++ b/src/studiolibrary/librarywindow.py
@@ -116,6 +116,9 @@ class LibraryWindow(QtWidgets.QWidget):
     MENUBAR_WIDGET_CLASS = studiolibrary.widgets.MenuBarWidget
     SIDEBAR_WIDGET_CLASS = studiolibrary.widgets.SidebarWidget
 
+    # Customize library classe
+    LIBRARY_CLASS = studiolibrary.Library
+
     @staticmethod
     def instances():
         """
@@ -230,7 +233,7 @@ class LibraryWindow(QtWidgets.QWidget):
         # Create Widgets
         # --------------------------------------------------------------------
 
-        library = studiolibrary.Library(libraryWindow=self)
+        library = self.LIBRARY_CLASS(libraryWindow=self)
         library.searchTimeFinished.connect(self._searchFinished)
 
         self._sidebarFrame = SidebarFrame(self)


### PR DESCRIPTION
Hello Kurt,

I've noticed you've removed the "createLibrary" method from the LibraryWindow, so I've exposed a LIBRARY_CLASS variable to be able to change the library used, and be consistent with the other variables that are exposed.

A lot has changed in the code and you removed a lot of forward send of the LibraryWindow instance.  I those changes the libraryItem never receives the LibraryWindow instance at creation.  Are you planning to completely remove the unused variable from the LibraryItem class?

Because of this the "Select Folder" option was not usable any more, I've changed it by a call to find back the window by traversing the widgets, I don't know if this is ok for you?

Cheers,
-jerome-
