### PR TITLE
Refactor obsolete method: table.setItemSelected() to item.setSelected()

### DIFF
--- a/src/studiolibrary/widgets/itemswidget/listview.py
+++ b/src/studiolibrary/widgets/itemswidget/listview.py
@@ -217,7 +217,7 @@ class ListView(ItemViewMixin, QtWidgets.QListView):
         """
         self.treeWidget().blockSignals(True)
         for item in items:
-            self.treeWidget().setItemSelected(item, value)
+            item.setSelected(value)
         self.treeWidget().blockSignals(False)
 
     def moveItems(self, items, itemAt):
@@ -309,7 +309,7 @@ class ListView(ItemViewMixin, QtWidgets.QListView):
         ItemViewMixin.mousePressEvent(self, event)
         if event.isAccepted():
             QtWidgets.QListView.mousePressEvent(self, event)
-            self.itemsWidget().treeWidget().setItemSelected(item, True)
+            item.setSelected(True)
 
         self.endDrag()
         self._dragStartPos = event.pos()

--- a/src/studiolibrary/widgets/itemswidget/treewidget.py
+++ b/src/studiolibrary/widgets/itemswidget/treewidget.py
@@ -123,7 +123,7 @@ class TreeWidget(ItemViewMixin, QtWidgets.QTreeWidget):
         :rtype: None
         """
         for item in items:
-            self.setItemSelected(item, value)
+            item.setSelected(value)
 
         if scrollTo:
             self.itemsWidget().scrollToSelectedItem()
@@ -488,7 +488,7 @@ class TreeWidget(ItemViewMixin, QtWidgets.QTreeWidget):
         self.setItemsCustomOrder(orderedItems)
 
         for item in items:
-            self.setItemSelected(item, True)
+            item.setSelected(True)
 
         self.itemsWidget().scrollToSelectedItem()
 


### PR DESCRIPTION
In refactoring our own code, we noticed it needed updating in studiolibrary as well.