### PR TITLE
Fix error when clicking on the background of ListView

### DIFF
--- a/src/studiolibrary/widgets/itemswidget/listview.py
+++ b/src/studiolibrary/widgets/itemswidget/listview.py
@@ -309,7 +309,8 @@ class ListView(ItemViewMixin, QtWidgets.QListView):
         ItemViewMixin.mousePressEvent(self, event)
         if event.isAccepted():
             QtWidgets.QListView.mousePressEvent(self, event)
-            item.setSelected(True)
+            if item:
+                item.setSelected(True)
 
         self.endDrag()
         self._dragStartPos = event.pos()


### PR DESCRIPTION
When clicking on the background of the ListView this exception is raised.
```python
# Traceback (most recent call last):
#   File "...\studiolibrary\widgets\itemswidget\listview.py", line 312, in mousePressEvent
#     item.setSelected(True)
# AttributeError: 'NoneType' object has no attribute 'setSelected'
```

This seems to be causing some odd behavior in the rubber band selection as well as raising the error.

This pull request fixes the problem by not calling `item.setSelected` if item is None.

![miCvBTc2WM](https://user-images.githubusercontent.com/2424292/68823721-772c6980-0649-11ea-9bd1-84bc8fe1e446.png)
