### PR TITLE
Fixed vendorised copy of Qt.py clashing

### DIFF
--- a/src/studiovendor/Qt.py
+++ b/src/studiovendor/Qt.py
@@ -1665,7 +1665,7 @@ def _install():
             setattr(our_submodule, member, their_member)
 
     # Enable direct import of QtCompat
-    sys.modules['Qt.QtCompat'] = Qt.QtCompat
+    sys.modules[__name__ + ".QtCompat"] = Qt.QtCompat
 
     # Backwards compatibility
     if hasattr(Qt.QtCompat, 'loadUi'):


### PR DESCRIPTION
The vendorised copy of Qt.py and another instance of Qt.py currently write to the same location in sys.modules, meaning that they clash with each other.
This change follows other usage of sys.modules in Qt.py and writes to the module location of the current instance of Qt.py, rather than to the global location.

I have submitted a similar change upstream to Qt.py here (https://github.com/mottosso/Qt.py/pull/355), which has been released as 1.3.3. So alternatively you could update Qt.py to that instead.