### PR TITLE
Fix README example to use proper argument

### DIFF
--- a/src/studiolibrarymaya/README.md
+++ b/src/studiolibrarymaya/README.md
@@ -32,7 +32,7 @@ path = "/AnimLibrary/Characters/Malcolm/malcolm.anim"
 objects = maya.cmds.ls(selection=True) or []
 
 # Saving an animation item
-animitem.save(path, objects=objects, startFrame=0, endFrame=200, bakeConnected=False)
+animitem.save(path, objects=objects, frameRange=(0, 200), bakeConnected=False)
 
 # Loading an animation item
 animitem.load(path, objects=objects, option="replace all", connect=False, currentTime=False)


### PR DESCRIPTION
The example for saving an animation item was using the incorrect frame range argument that was meant for loading an animation item. The save function mutils.SaveAnim expects a frameRange argument tuple instead of startFrame and endFrame.