### PR TITLE
Add relative posing support to apply a pose relative to the selected …

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -19,6 +19,7 @@ Please feel free to improve this page as needed. Thank you.
 * [How to lock and unlock specific folders](#we7zm9m)
 * [How to install & run for Maya 2011-2015](#qiot1k3)
 * [How to use relative posing](#4251ca)
+* [How to auto specify the relative posing control list file](#2afb7a)
 
 
 ### FAQ
@@ -295,5 +296,33 @@ path to the control list. Then select the control you want to use
 as the "anchor" and apply the pose. If you get an unexpected
 result, verify that the controls are listed in evaulation order.
 Relative posing also works with mirroring.
+
+[Top](#top)
+ 
+<br>
+
+### <a name="2afb7a"></a> How to auto specify the relative posing control list file
+ 
+Rather than setting the relative pose control list file path manually in the UI,
+you can set up a callback to query for the file path based on the current selection.
+
+```python
+import studiolibrary
+import maya.cmds as cmds
+
+def get_control_list_file(selection):
+    # Maybe the path is saved on an attribute in this namespace
+    if not selection:
+        return None
+    namespace = selection[0].split(":")[0]
+    attribute = "controlListAttribute"
+    attr = cmds.ls("{}:*.{}".format(namespace, attribute))
+    if not attr:
+        return None
+    return cmds.getAttr(attr[0])
+
+studiolibrary.setRelativePoseControlListCallback(get_control_list_file)
+studiolibrary.main()
+```
 
 [Top](#top)

--- a/DOCS.md
+++ b/DOCS.md
@@ -272,20 +272,30 @@ In order for this to work, two new options were added:
 
 - A boolean toggle called "relativeTo" to enable this functionality
 
-- A file path to a text file listing all the controls in evaluation order.
+- A file path to a text file listing the top level controls and controls that have a
+world space constraint.
 
 The text file listing the controls is required in order to properly place
-all controls. It should list a control per line in evaluation order. For
-example:
+controls. It should list a control per line and list the top level controls
+and controls with a world space constraint option. For
+example with the Mery rig, we list the main torso control, the upper arm fk
+controls because they have a global space switch option, the pole vector controls,
+the ik controls, the head, and eyes.
 
 ```
-spine_01
-spine_02
-spine_03
-clavicle_l
-shoulder_l
-elbow_l
-hand_l
+Mery_ac_cn_torso
+Mery_ac_lf_uparm
+Mery_ac_rg_uparm
+Mery_ac_lf_elbowPivot
+Mery_ac_rg_elbowPivot
+Mery_ac_lf_ikhand
+Mery_ac_rg_ikhand
+Mery_ac_cn_head
+Mery_ac_cn_eyes
+Mery_ac_lf_kneePivot
+Mery_ac_lf_ikfoot
+Mery_ac_rg_kneePivot
+Mery_ac_rg_ikfoot
 ```
 
 The control list definition file could not be automated because

--- a/DOCS.md
+++ b/DOCS.md
@@ -18,6 +18,7 @@ Please feel free to improve this page as needed. Thank you.
 * [How to fix a scene that has unknown nodes](#ufj2oi4)
 * [How to lock and unlock specific folders](#we7zm9m)
 * [How to install & run for Maya 2011-2015](#qiot1k3)
+* [How to use relative posing](#4251ca)
 
 
 ### FAQ
@@ -255,5 +256,44 @@ Use ⌘+Shift+G in the finder and copy the studiolibrary folder to
 import studiolibrary
 studiolibrary.main()
 ```
+
+[Top](#top)
+
+<br>
+
+### <a name="4251ca"></a> How to use relative posing
+
+Relative posing allows users to place a control, for example the ik foot, and then apply
+a pose so that the selected control, in this example the ik foot,
+remains in place and the pose is applied relative to that location.
+
+In order for this to work, two new options were added:
+
+- A boolean toggle called "relativeTo" to enable this functionality
+
+- A file path to a text file listing all the controls in evaluation order.
+
+The text file listing the controls is required in order to properly place
+all controls. It should list a control per line in evaluation order. For
+example:
+
+```
+spine_01
+spine_02
+spine_03
+clavicle_l
+shoulder_l
+elbow_l
+hand_l
+```
+
+The control list definition file could not be automated because
+controls could be driven by arbitrary networks.
+
+To use the functionality, enable the relativeTo option and set the
+path to the control list. Then select the control you want to use
+as the "anchor" and apply the pose. If you get an unexpected
+result, verify that the controls are listed in evaulation order.
+Relative posing also works with mirroring.
 
 [Top](#top)

--- a/src/mutils/pose.py
+++ b/src/mutils/pose.py
@@ -55,11 +55,14 @@ pose.load(objects=["Character1:Hand_L", "Character1:Finger_L"])
 
 """
 import logging
+import os
+import re
 
 import mutils
 
 try:
     import maya.cmds
+    import maya.api.OpenMaya as OpenMaya
 except ImportError:
     import traceback
     traceback.print_exc()
@@ -345,6 +348,7 @@ class Pose(mutils.TransferObject):
             key=False,
             mirror=False,
             additive=False,
+            relativeTo=None,
             refresh=False,
             batchMode=False,
             clearCache=False,
@@ -365,6 +369,7 @@ class Pose(mutils.TransferObject):
         :type refresh: bool
         :type mirror: bool
         :type additive: bool
+        :type relativeTo: str or None
         :type mirrorTable: mutils.MirrorTable
         :type batchMode: bool
         :type clearCache: bool
@@ -386,9 +391,11 @@ class Pose(mutils.TransferObject):
             attrs=attrs,
             batchMode=batchMode,
             clearCache=clearCache,
+            mirror=mirror,
             mirrorTable=mirrorTable,
             onlyConnected=onlyConnected,
             ignoreConnected=ignoreConnected,
+            relativeTo=relativeTo,
             searchAndReplace=searchAndReplace,
         )
 
@@ -414,9 +421,11 @@ class Pose(mutils.TransferObject):
             attrs=None,
             ignoreConnected=False,
             onlyConnected=False,
+            mirror=False,
             mirrorTable=None,
             batchMode=False,
             clearCache=True,
+            relativeTo=False,
             searchAndReplace=None,
     ):
         """
@@ -429,7 +438,9 @@ class Pose(mutils.TransferObject):
         :type onlyConnected: bool
         :type clearCache: bool
         :type batchMode: bool
+        :type mirror: bool
         :type mirrorTable: mutils.MirrorTable
+        :type relativeTo: str or None
         :type searchAndReplace: (str, str) or None
         """
         if clearCache or not batchMode or not self._mtime:
@@ -453,7 +464,7 @@ class Pose(mutils.TransferObject):
             self._cache = []
             self._cacheKey = cacheKey
 
-            dstObjects = objects
+            dstObjects = [] if relativeTo else objects
             srcObjects = self.objects()
             usingNamespaces = not objects and namespaces
 
@@ -474,6 +485,8 @@ class Pose(mutils.TransferObject):
                 replace=replace,
             )
 
+            # Store the dstNodes in case we need them for relative posing
+            dstNodes = []
             for srcNode, dstNode in matches:
                 self.cacheNode(
                     srcNode,
@@ -483,6 +496,14 @@ class Pose(mutils.TransferObject):
                     ignoreConnected=ignoreConnected,
                     usingNamespaces=usingNamespaces,
                 )
+                dstNodes.append(dstNode)
+
+            if relativeTo and objects:
+                # Update cache to contain values relative to the selected node
+                self._makeCacheRelative(objects[0],
+                                        dstNodes,
+                                        controlListFile=relativeTo,
+                                        mirror=mirror)
 
         if not self.cache():
             text = "No objects match when loading data. " \
@@ -564,6 +585,78 @@ class Pose(mutils.TransferObject):
             dstAttribute.update()
 
             self._cache.append((srcAttribute, dstAttribute, srcMirrorValue))
+
+    def _makeCacheRelative(self, rootNode, dstNodes, controlListFile, mirror):
+        """
+        Modifies the cache to be relative to the specified node
+
+        :type rootNode: str
+        :type dstNodes: list[str]
+        :type controlListFile: str
+        :type mirror: bool
+        :rtype: None
+        """
+        selectionList = OpenMaya.MSelectionList()
+        selectionList.add(rootNode)
+        pathRootNode = selectionList.getDagPath(0)
+        rootStart = pathRootNode.inclusiveMatrix()
+
+        # Open undo chunk
+        maya.cmds.undoInfo(openChunk=True)
+        # Go to the pose and calculate the delta xform to keep the root node in place
+        self.loadCache(mirror=mirror)
+        # Get the offset of the rootNode
+        rootEnd = pathRootNode.inclusiveMatrix()
+        rootOffset = (rootEnd.inverse() * rootStart)
+
+        # Sort dstNodes based on control list file
+        # They need to be in evalution order so we can calculate proper local channels
+        if os.path.isfile(controlListFile):
+            with open(controlListFile, "r") as fh:
+                nodes = [node.strip() for node in fh.readlines() if node]
+
+            for node in dstNodes:
+                nodeName = node.name().split(":")[-1]
+                try:
+                    index = nodes.index(nodeName)
+                except ValueError:
+                    index = 100000
+                node.sortIndex = index
+            dstNodes = sorted(dstNodes, key=lambda x: x.sortIndex)
+        else:
+            maya.cmds.warning("Control file does not exist. Relative posing may be inaccurate.")
+
+        xforms = {}
+        for node in dstNodes:
+            name = node.name()
+            if not maya.cmds.objectType(name, isAType="transform"):
+                continue
+
+            selectionList = OpenMaya.MSelectionList()
+            selectionList.add(name)
+            path = selectionList.getDagPath(0)
+            currentXform = path.inclusiveMatrix()
+            newXform = currentXform * rootOffset
+            xforms[name] = newXform
+
+        for node in dstNodes:
+            name = node.name()
+            if not maya.cmds.objectType(name, isAType="transform"):
+                continue
+            m = xforms[name]
+            maya.cmds.xform(name, ws=True, m=m)
+            for i, values in enumerate(self.cache()):
+                srcAttribute, dstAttribute, srcMirrorValue = values
+                if srcAttribute and dstAttribute and dstAttribute.name() == name:
+                    if re.search("(translate|rotate|scale)", srcAttribute.fullname()):
+                        value = maya.cmds.getAttr(dstAttribute.fullname())
+                        # Update the cache with the new value
+                        if mirror:
+                            self._cache[i] = (srcAttribute, dstAttribute, value)
+                        else:
+                            srcAttribute._value = value
+        maya.cmds.undoInfo(closeChunk=True)
+        maya.cmds.undo()
 
     def loadCache(self, blend=100, key=False, mirror=False, additive=False):
         """

--- a/src/mutils/pose.py
+++ b/src/mutils/pose.py
@@ -620,7 +620,7 @@ class Pose(mutils.TransferObject):
                 try:
                     index = nodes.index(nodeName)
                 except ValueError:
-                    index = 100000
+                    index = -1
                 node.sortIndex = index
             dstNodes = sorted(dstNodes, key=lambda x: x.sortIndex)
         else:
@@ -640,6 +640,9 @@ class Pose(mutils.TransferObject):
             xforms[name] = newXform
 
         for node in dstNodes:
+            if getattr(node, "sortIndex", -1) == -1:
+                # Don't update nodes not specified in the control list
+                continue
             name = node.name()
             if not maya.cmds.objectType(name, isAType="transform"):
                 continue

--- a/src/studiolibrary/utils.py
+++ b/src/studiolibrary/utils.py
@@ -99,6 +99,8 @@ __all__ = [
     "registeredItems",
     "runTests",
     "findItemsInFolders",
+    "setRelativePoseControlListCallback",
+    "relativePoseControlListCallback",
 ]
 
 
@@ -1465,6 +1467,27 @@ def showInFolder(path):
 
     logger.info("Call: '%s' with arguments: %s", cmd.__name__, args)
     cmd(*args)
+
+
+_relativePoseControlListCallback = None
+
+
+def setRelativePoseControlListCallback(func):
+    """Users can use this to auto query for a control list definition file
+    used with relative posing.
+
+    :type func: function with a single list argument representing the current
+    selection. This function should use the selection to return the associated
+    control list file path.
+    """
+    global _relativePoseControlListCallback
+    _relativePoseControlListCallback = func
+
+
+def relativePoseControlListCallback():
+    """Get the relative pose control list query callback"""
+    global _relativePoseControlListCallback
+    return _relativePoseControlListCallback
 
 
 def testNormPath():

--- a/src/studiolibrary/widgets/fieldwidgets.py
+++ b/src/studiolibrary/widgets/fieldwidgets.py
@@ -10,6 +10,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import re
 import logging
 import functools
@@ -765,11 +766,19 @@ class PathFieldWidget(StringFieldWidget):
     def browse(self):
         """Open the file dialog."""
         path = self.value()
-        path = QtWidgets.QFileDialog.getExistingDirectory(
-            None,
-            "Browse Folder",
-            path
-        )
+        pathType = self.data().get("pathType")
+        if pathType == "file":
+            path, _ = QtWidgets.QFileDialog.getOpenFileName(
+                None,
+                "Browse File",
+                os.path.dirname(path)
+            )
+        else:
+            path = QtWidgets.QFileDialog.getExistingDirectory(
+                None,
+                "Browse Folder",
+                path
+            )
         if path:
             self.setValue(path)
 

--- a/src/studiolibrarymaya/poseitem.py
+++ b/src/studiolibrarymaya/poseitem.py
@@ -320,6 +320,14 @@ class PoseItem(baseitem.BaseItem):
                 "persistent": True,
             },
             {
+                "name": "minimizeRotations",
+                "title": "Minimize Rotations",
+                "type": "bool",
+                "inline": True,
+                "default": True,
+                "persistent": True,
+            },
+            {
                 "name": "relativeToControlList",
                 "title": "Control List",
                 "type": "path",
@@ -391,6 +399,10 @@ class PoseItem(baseitem.BaseItem):
                 "visible": values.get("searchAndReplaceEnabled")
             },
             {
+                "name": "minimizeRotations",
+                "visible": values.get("relativeTo")
+            },
+            {
                 "name": "relativeToControlList",
                 "visible": values.get("relativeTo")
             },
@@ -427,12 +439,14 @@ class PoseItem(baseitem.BaseItem):
             self._options['additive'] = self.currentLoadValue("additive")
 
         relativeTo = None
+        minimizeRotations = True
         if self.currentLoadValue("relativeTo"):
             callback = studiolibrary.relativePoseControlListCallback()
             if callback:
                 relativeTo = callback(maya.cmds.ls(selection=True))
             else:
                 relativeTo = self.currentLoadValue("relativeToControlList")
+            minimizeRotations = self.currentLoadValue("minimizeRotations")
 
         searchAndReplace = None
         if self.currentLoadValue("searchAndReplaceEnabled"):
@@ -448,6 +462,7 @@ class PoseItem(baseitem.BaseItem):
                 showBlendMessage=showBlendMessage,
                 searchAndReplace=searchAndReplace,
                 relativeTo=relativeTo,
+                minimizeRotations=minimizeRotations,
                 **self._options
             )
         except Exception as error:
@@ -464,6 +479,7 @@ class PoseItem(baseitem.BaseItem):
         mirror=None,
         additive=False,
         relativeTo=None,
+        minimizeRotations=True,
         refresh=True,
         batchMode=False,
         clearCache=False,
@@ -483,6 +499,7 @@ class PoseItem(baseitem.BaseItem):
         :type attrs: list[str] or None
         :type mirror: bool or None
         :type relativeTo: str or None
+        :type minimizeRotations: bool
         :type batchMode: bool
         :type showBlendMessage: bool
         :type clearSelection: bool
@@ -516,6 +533,7 @@ class PoseItem(baseitem.BaseItem):
                 mirror=mirror,
                 additive=additive,
                 relativeTo=relativeTo,
+                minimizeRotations=minimizeRotations,
                 refresh=refresh,
                 batchMode=batchMode,
                 clearCache=clearCache,

--- a/src/studiolibrarymaya/poseitem.py
+++ b/src/studiolibrarymaya/poseitem.py
@@ -313,6 +313,20 @@ class PoseItem(baseitem.BaseItem):
                 "persistent": True,
             },
             {
+                "name": "relativeTo",
+                "type": "bool",
+                "inline": True,
+                "default": False,
+                "persistent": True,
+            },
+            {
+                "name": "relativeToControlList",
+                "title": "Control List",
+                "type": "path",
+                "pathType": "file",
+                "persistent": True,
+            },
+            {
                 "name": "searchAndReplaceEnabled",
                 "title": "Search and Replace",
                 "type": "bool",
@@ -376,6 +390,10 @@ class PoseItem(baseitem.BaseItem):
                 "name": "searchAndReplace",
                 "visible": values.get("searchAndReplaceEnabled")
             },
+            {
+                "name": "relativeToControlList",
+                "visible": values.get("relativeTo")
+            },
         ]
 
         fields.extend(super(PoseItem, self).loadValidator(**values))
@@ -408,6 +426,10 @@ class PoseItem(baseitem.BaseItem):
             self._options['objects'] = maya.cmds.ls(selection=True) or []
             self._options['additive'] = self.currentLoadValue("additive")
 
+        relativeTo = None
+        if self.currentLoadValue("relativeTo"):
+            relativeTo = self.currentLoadValue("relativeToControlList")
+
         searchAndReplace = None
         if self.currentLoadValue("searchAndReplaceEnabled"):
             searchAndReplace = self.currentLoadValue("searchAndReplace")
@@ -421,6 +443,7 @@ class PoseItem(baseitem.BaseItem):
                 clearSelection=clearSelection,
                 showBlendMessage=showBlendMessage,
                 searchAndReplace=searchAndReplace,
+                relativeTo=relativeTo,
                 **self._options
             )
         except Exception as error:
@@ -436,6 +459,7 @@ class PoseItem(baseitem.BaseItem):
         attrs=None,
         mirror=None,
         additive=False,
+        relativeTo=None,
         refresh=True,
         batchMode=False,
         clearCache=False,
@@ -454,6 +478,7 @@ class PoseItem(baseitem.BaseItem):
         :type refresh: bool
         :type attrs: list[str] or None
         :type mirror: bool or None
+        :type relativeTo: str or None
         :type batchMode: bool
         :type showBlendMessage: bool
         :type clearSelection: bool
@@ -486,6 +511,7 @@ class PoseItem(baseitem.BaseItem):
                 attrs=attrs,
                 mirror=mirror,
                 additive=additive,
+                relativeTo=relativeTo,
                 refresh=refresh,
                 batchMode=batchMode,
                 clearCache=clearCache,

--- a/src/studiolibrarymaya/poseitem.py
+++ b/src/studiolibrarymaya/poseitem.py
@@ -428,7 +428,11 @@ class PoseItem(baseitem.BaseItem):
 
         relativeTo = None
         if self.currentLoadValue("relativeTo"):
-            relativeTo = self.currentLoadValue("relativeToControlList")
+            callback = studiolibrary.relativePoseControlListCallback()
+            if callback:
+                relativeTo = callback(maya.cmds.ls(selection=True))
+            else:
+                relativeTo = self.currentLoadValue("relativeToControlList")
 
         searchAndReplace = None
         if self.currentLoadValue("searchAndReplaceEnabled"):


### PR DESCRIPTION
Add relative posing support to apply a pose relative to the selected control

Allows users to place a control, for example the ik foot, and then apply
a pose so that the selected control, in this example the ik foot,
remains in place and the pose is applied relative to that location.

![Relative Posing](https://i.imgur.com/aPblMXs.gif)

In order for this to work, two new options were added:

-  A boolean toggle called "relativeTo"  to enable this functionality
- A file path to a text file listing the top level controls and controls that have a
 world space constraint.

The text file listing the controls is required in order to properly place
controls. It should list a control per line and list the top level controls
and controls with a world space constraint option. For
example with the Mery rig, we list the main torso control, the upper arm fk
controls because they have a global space switch option, the pole vector controls,
the ik controls, the head, and eyes.

```
Mery_ac_cn_torso
Mery_ac_lf_uparm
Mery_ac_rg_uparm
Mery_ac_lf_elbowPivot
Mery_ac_rg_elbowPivot
Mery_ac_lf_ikhand
Mery_ac_rg_ikhand
Mery_ac_cn_head
Mery_ac_cn_eyes
Mery_ac_lf_kneePivot
Mery_ac_lf_ikfoot
Mery_ac_rg_kneePivot
Mery_ac_rg_ikfoot
```

The control list definition file could not be automated because
controls could be driven by arbitrary networks.

To use the functionality, enable the relativeTo option and set the
path to the control list. Then select the control you want to use
as the "anchor" and apply the pose. If you get an unexpected
result, verify that all top level and world constrained controls are listed.
Relative posing also works with mirroring.