### PR TITLE
Namespace Mapping Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Studio Library is a python-based Qt tool for managing poses and animation in Maya.
 
+## Version 3.0
+
+We are excitedly working on our upcoming major release! In order to ensure smooth progress, we kindly request that merge requests primarily focus on fixes or small changes. Thank you. 
+
 
 ## Features 
 

--- a/src/mutils/matchnames.py
+++ b/src/mutils/matchnames.py
@@ -13,6 +13,7 @@
 import logging
 
 import mutils
+from collections import OrderedDict
 
 __all__ = [
     "matchNames",
@@ -39,11 +40,12 @@ def groupObjects(objects):
     :type objects:
     :rtype:
     """
-    results = {}
+    results = OrderedDict()
     for name in objects:
         node = mutils.Node(name)
         results.setdefault(node.namespace(), [])
         results[node.namespace()].append(name)
+    results = OrderedDict(sorted(results.items(), key=lambda t: (t[0].count(":"), len(t[0]))))
     return results
 
 
@@ -104,10 +106,12 @@ def matchNames(srcObjects, dstObjects=None, dstNamespaces=None, search=None, rep
 
     dstIndex = indexObjects(dstObjects)
     # DESTINATION NAMESPACES NOT IN SOURCE OBJECTS
-    dstNamespaces2 = list(set(dstNamespaces) - set(srcNamespaces))
+    # dstNamespaces2 = list(set(dstNamespaces) - set(srcNamespaces))
+    dstNamespaces2 = [x for x in dstNamespaces if x not in srcNamespaces]
 
     # DESTINATION NAMESPACES IN SOURCE OBJECTS
-    dstNamespaces1 = list(set(dstNamespaces) - set(dstNamespaces2))
+    # dstNamespaces1 = list(set(dstNamespaces) - set(dstNamespaces2))
+    dstNamespaces1 = [x for x in dstNamespaces if x not in dstNamespaces2]
 
     # CACHE DESTINATION OBJECTS WITH NAMESPACES IN SOURCE OBJECTS
     usedNamespaces = []

--- a/src/mutils/matchnames.py
+++ b/src/mutils/matchnames.py
@@ -106,11 +106,9 @@ def matchNames(srcObjects, dstObjects=None, dstNamespaces=None, search=None, rep
 
     dstIndex = indexObjects(dstObjects)
     # DESTINATION NAMESPACES NOT IN SOURCE OBJECTS
-    # dstNamespaces2 = list(set(dstNamespaces) - set(srcNamespaces))
     dstNamespaces2 = [x for x in dstNamespaces if x not in srcNamespaces]
 
     # DESTINATION NAMESPACES IN SOURCE OBJECTS
-    # dstNamespaces1 = list(set(dstNamespaces) - set(dstNamespaces2))
     dstNamespaces1 = [x for x in dstNamespaces if x not in dstNamespaces2]
 
     # CACHE DESTINATION OBJECTS WITH NAMESPACES IN SOURCE OBJECTS

--- a/src/mutils/namespace.py
+++ b/src/mutils/namespace.py
@@ -41,7 +41,6 @@ def getFromDagPaths(dagPaths):
         namespace = getFromDagPath(dagPath)
         namespaces.append(namespace)
 
-    # return list(set(namespaces))
     return namespaces
 
 
@@ -70,7 +69,6 @@ def getFromSelection():
         # Catch any errors when running this command outside of Maya
         logger.exception(error)
 
-    # return namespaces
     return list(OrderedDict.fromkeys(namespaces))
 
 

--- a/src/mutils/namespace.py
+++ b/src/mutils/namespace.py
@@ -11,6 +11,7 @@
 # License along with this library. If not, see <http://www.gnu.org/licenses/>.
 import logging
 import traceback
+from collections import OrderedDict
 
 try:
     import maya.cmds
@@ -40,7 +41,8 @@ def getFromDagPaths(dagPaths):
         namespace = getFromDagPath(dagPath)
         namespaces.append(namespace)
 
-    return list(set(namespaces))
+    # return list(set(namespaces))
+    return namespaces
 
 
 def getFromDagPath(dagPath):
@@ -68,7 +70,8 @@ def getFromSelection():
         # Catch any errors when running this command outside of Maya
         logger.exception(error)
 
-    return namespaces
+    # return namespaces
+    return list(OrderedDict.fromkeys(namespaces))
 
 
 def getAll():

--- a/src/studiolibrary/__init__.py
+++ b/src/studiolibrary/__init__.py
@@ -10,7 +10,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "2.10.2"
+__version__ = "2.10.3"
 
 
 def version():

--- a/src/studiolibrarymaya/poseitem.py
+++ b/src/studiolibrarymaya/poseitem.py
@@ -94,15 +94,26 @@ class PoseLoadWidget(baseloadwidget.BaseLoadWidget):
 
     def _sliderReleased(self):
         """Triggered when the user releases the slider handle."""
-        self.load(blend=self.ui.blendSlider.value(), refresh=False)
+        try:
+            self.load(blend=self.ui.blendSlider.value(), refresh=False)
+            self._options = {}
+        except Exception as error:
+            self.item().showErrorDialog("Item Error", str(error))
+            raise
 
     def _blendEditChanged(self, *args):
         """Triggered when the user changes the blend edit value."""
-        self.load(blend=int(self.ui.blendEdit.text()), clearSelection=False)
+        try:
+            self._options = {}
+            self.load(blend=int(self.ui.blendEdit.text()), clearSelection=False)
+        except Exception as error:
+            self.item().showErrorDialog("Item Error", str(error))
+            raise
 
     def accept(self):
         """Triggered when the user clicks the apply button."""
         try:
+            self._options = {}
             self.load(clearCache=True,  clearSelection=False)
         except Exception as error:
             self.item().showErrorDialog("Item Error", str(error))
@@ -128,7 +139,6 @@ class PoseLoadWidget(baseloadwidget.BaseLoadWidget):
         if batchMode:
             self.formWidget().setValidatorEnabled(False)
         else:
-            self._options = {}
             self.formWidget().setValidatorEnabled(True)
 
         if not self._options:


### PR DESCRIPTION
Hey,

We have been running into issues with assets that have nested references therefore nested namespaces.

# Issue
When you set the Namespace to `From selection` it would not stick to the order you selected the items in. Therefor the namespaces could not align. Occasion when the nested namespace would come first and the root second, no matter how you select the controllers or set the custom.

# Example
## Namespace
### AChar
namespace is `AChar, AChar:Box` therefor:
- `From file` = `AChar, AChar:Box`
### BChar namespace is `BChar, BChar:Axe` therefor:
- `From file` = `BChar:Axe, BChar`

If we use the animation from AChar onto BChar
### AChar
- `From file` = `A, A:B`
### BChar
- Select two controllers with the two namespaces respectively.
- `From selection` = `B:A, B` (no matter the order you select the controllers)
- `Use custom` does not seem to respect the order you place either.

# Solution
## Name Space > From selection
- Now abides by the order it is selected or set in.

Thanks