### PR TITLE
Namespace Mapping Fix

### DIFF
--- a/src/mutils/matchnames.py
+++ b/src/mutils/matchnames.py
@@ -13,6 +13,7 @@
 import logging
 
 import mutils
+from collections import OrderedDict
 
 __all__ = [
     "matchNames",
@@ -39,11 +40,12 @@ def groupObjects(objects):
     :type objects:
     :rtype:
     """
-    results = {}
+    results = OrderedDict()
     for name in objects:
         node = mutils.Node(name)
         results.setdefault(node.namespace(), [])
         results[node.namespace()].append(name)
+    results = OrderedDict(sorted(results.items(), key=lambda t: (t[0].count(":"), len(t[0]))))
     return results
 
 
@@ -104,10 +106,10 @@ def matchNames(srcObjects, dstObjects=None, dstNamespaces=None, search=None, rep
 
     dstIndex = indexObjects(dstObjects)
     # DESTINATION NAMESPACES NOT IN SOURCE OBJECTS
-    dstNamespaces2 = list(set(dstNamespaces) - set(srcNamespaces))
+    dstNamespaces2 = [x for x in dstNamespaces if x not in srcNamespaces]
 
     # DESTINATION NAMESPACES IN SOURCE OBJECTS
-    dstNamespaces1 = list(set(dstNamespaces) - set(dstNamespaces2))
+    dstNamespaces1 = [x for x in dstNamespaces if x not in dstNamespaces2]
 
     # CACHE DESTINATION OBJECTS WITH NAMESPACES IN SOURCE OBJECTS
     usedNamespaces = []

--- a/src/mutils/namespace.py
+++ b/src/mutils/namespace.py
@@ -11,6 +11,7 @@
 # License along with this library. If not, see <http://www.gnu.org/licenses/>.
 import logging
 import traceback
+from collections import OrderedDict
 
 try:
     import maya.cmds
@@ -40,7 +41,7 @@ def getFromDagPaths(dagPaths):
         namespace = getFromDagPath(dagPath)
         namespaces.append(namespace)
 
-    return list(set(namespaces))
+    return namespaces
 
 
 def getFromDagPath(dagPath):
@@ -68,7 +69,7 @@ def getFromSelection():
         # Catch any errors when running this command outside of Maya
         logger.exception(error)
 
-    return namespaces
+    return list(OrderedDict.fromkeys(namespaces))
 
 
 def getAll():


### PR DESCRIPTION
Hey,

We have been running into issues with assets that have nested references therefore nested namespaces.

# Issue
When you set the Namespace to `From selection` it would not stick to the order you selected the items in. Therefor the namespaces could not align. Occasion when the nested namespace would come first and the root second, no matter how you select the controllers or set the custom.

# Example
## Namespace
### AChar
namespace is `AChar, AChar:Box` therefor:
- `From file` = `AChar, AChar:Box`
### BChar namespace is `BChar, BChar:Axe` therefor:
- `From file` = `BChar:Axe, BChar`

If we use the animation from AChar onto BChar
### AChar
- `From file` = `A, A:B`
### BChar
- Select two controllers with the two namespaces respectively.
- `From selection` = `B:A, B` (no matter the order you select the controllers)
- `Use custom` does not seem to respect the order you place either.

# Solution
## Name Space > From selection
- Now abides by the order it is selected or set in.

Thanks