### PR TITLE
Fix 'charmap' codec can't decode byte issue

### DIFF
--- a/src/mutils/animation.py
+++ b/src/mutils/animation.py
@@ -563,7 +563,7 @@ class Animation(mutils.Pose):
         """
         file_extension = os.path.splitext(path)[1]
         if file_extension == ".mb":
-            logger.warning("Binary file detected: " + path + ". Skipping clean.")
+            logger.info("Binary file detected: " + path + ". Skipping clean.")
             return
 
         results = []

--- a/src/mutils/animation.py
+++ b/src/mutils/animation.py
@@ -561,8 +561,8 @@ class Animation(mutils.Pose):
         Clean up all commands in the exported maya file that are
         not createNode.
         """
-        file_extension = os.path.splitext(path)[1]
-        if file_extension == ".mb":
+        fileExtension = os.path.splitext(path)[1]
+        if fileExtension == ".mb":
             logger.info("Binary file detected: " + path + ". Skipping clean.")
             return
 

--- a/src/mutils/animation.py
+++ b/src/mutils/animation.py
@@ -561,6 +561,11 @@ class Animation(mutils.Pose):
         Clean up all commands in the exported maya file that are
         not createNode.
         """
+        file_extension = os.path.splitext(path)[1]
+        if file_extension == ".mb":
+            logger.warning("Binary file detected: " + path + ". Skipping clean.")
+            return
+
         results = []
 
         if path.endswith(".mb"):


### PR DESCRIPTION
From what I could tell, the `cleanMayaFile` function in `animation.py` attempts to open the temp Maya file to clean out unnecessary nodes. However, this won't work on binary files, so I added a snippet to skip any detected binary files.

Should resolve the following issues: 
#427 
#400 
#395 
#390 
#370 
#365 
#360 
#349 
#345