### PR TITLE
Fix listdir on Windows share with no permission to list root

### DIFF
--- a/src/studiolibrary/utils.py
+++ b/src/studiolibrary/utils.py
@@ -1237,18 +1237,25 @@ def walkup(path, match=None, depth=3, sep="/"):
     depthCount = 0
 
     for i, folder in enumerate(folders):
-        if folder:
+        if not folder:
+            continue
 
-            if depthCount > depth:
-                break
-            depthCount += 1
+        if depthCount > depth:
+            break
+        depthCount += 1
 
-            folder = os.path.sep.join(folders[:i*-1])
-            if os.path.exists(folder):
-                for filename in os.listdir(folder):
-                    path = os.path.join(folder, filename)
-                    if match is None or match(path):
-                        yield normPath(path)
+        folder = os.path.sep.join(folders[:i*-1])
+        if not os.path.exists(folder):
+            continue
+        try:
+            for filename in os.listdir(folder):
+                path = os.path.join(folder, filename)
+                if match is None or match(path):
+                    yield normPath(path)
+        except OSError as e:
+            if 'An unexpected network error occurred' in e.strerror:
+                continue  # skip permission errors for '\\share\root'
+            raise
 
 
 def timeAgo(timeStamp):

--- a/src/studiolibrary/utils.py
+++ b/src/studiolibrary/utils.py
@@ -1245,17 +1245,20 @@ def walkup(path, match=None, depth=3, sep="/"):
         depthCount += 1
 
         folder = os.path.sep.join(folders[:i*-1])
-        if not os.path.exists(folder):
+        if not os.path.isdir(folder):
             continue
         try:
-            for filename in os.listdir(folder):
-                path = os.path.join(folder, filename)
-                if match is None or match(path):
-                    yield normPath(path)
+            filenames = os.listdir(folder)
+        except PermissionError:
+            continue
         except OSError as e:
-            if 'An unexpected network error occurred' in e.strerror:
-                continue  # skip permission errors for '\\share\root'
+            if 'unexpected network error' in e.strerror:
+                continue  # skip specific permission errors on network shares
             raise
+        for filename in filenames:
+            path = os.path.join(folder, filename)
+            if match is None or match(path):
+                yield normPath(path)
 
 
 def timeAgo(timeStamp):

--- a/src/studiolibrary/utils.py
+++ b/src/studiolibrary/utils.py
@@ -1250,11 +1250,7 @@ def walkup(path, match=None, depth=3, sep="/"):
         try:
             filenames = os.listdir(folder)
         except PermissionError:
-            continue
-        except OSError as e:
-            if 'unexpected network error' in e.strerror:
-                continue  # skip specific permission errors on network shares
-            raise
+            continue  # expected on network shares
         for filename in filenames:
             path = os.path.join(folder, filename)
             if match is None or match(path):


### PR DESCRIPTION
Not sure it is correct exception handling, and not sure it is `listdir()`, it just raises same exception as `scandir` but not `listdir` so i do not realize something here.

Closes #435 