### PR TITLE
Adds the ability to save and load timeslider bookmarks on the timeline to Studio Library

### DIFF
--- a/src/mutils/animation.py
+++ b/src/mutils/animation.py
@@ -643,6 +643,7 @@ class Animation(mutils.Pose):
                   "Please create a pose instead!"
             raise AnimationTransferError(msg)
         
+        #Bake bookmark data into metadata
         if bakeBookmarks:
             #Load bookmark plugin
             maya.cmds.loadPlugin('timeSliderBookmark')
@@ -662,7 +663,6 @@ class Animation(mutils.Pose):
                 bookmarkSaves.append(str(bookmarkData))
                 print('baked a bookmark of name ' + name)
 
-            print("baking bookmarks")
             self.setMetadata("bookmarks", bookmarkSaves)
 
         self.setMetadata("endFrame", end)
@@ -880,13 +880,12 @@ class Animation(mutils.Pose):
                         value = self.attrValue(srcNode.name(), attr)
                         dstAttr.setStaticKeyframe(value, dstTime, option)
                 
-                 #load animation bookmarks
+            #load animation bookmarks
             maya.cmds.loadPlugin('timeSliderBookmark')  
             bookmarks = self.bookmarks()
 
             if bookmarks is not None:
                 for bookmark in bookmarks:
-                    print("WE FOUND A BOOKMARK")
                     #format = ({name}{start}{stop}{color r}{color b}{color c})
                     split = re.findall('\{(.*?)\}', bookmark)
 

--- a/src/mutils/animation.py
+++ b/src/mutils/animation.py
@@ -90,7 +90,8 @@ def saveAnim(
         metadata=None,
         iconPath="",
         sequencePath="",
-        bakeConnected=True
+        bakeConnected=True,
+        bakeBookmarks=False
 ):
     """
     Save the anim data for the given objects.
@@ -113,6 +114,7 @@ def saveAnim(
     :type sequencePath: str
     :type metadata: dict or None
     :type bakeConnected: bool
+    :type bakeBookmarks: bool
     
     :rtype: mutils.Animation
     """
@@ -132,7 +134,8 @@ def saveAnim(
         time=time,
         sampleBy=sampleBy,
         fileType=fileType,
-        bakeConnected=bakeConnected
+        bakeConnected=bakeConnected,
+        bakeBookmarks=bakeBookmarks
     )
     return anim
 
@@ -587,7 +590,8 @@ class Animation(mutils.Pose):
         time=None,
         sampleBy=1,
         fileType="",
-        bakeConnected=True
+        bakeConnected=True,
+        bakeBookmarks=False
     ):
         """
         Save all animation data from the objects set on the Anim object.
@@ -597,6 +601,7 @@ class Animation(mutils.Pose):
         :type sampleBy: int
         :type fileType: str
         :type bakeConnected: bool
+        :type bakeBookmarks: bool
         
         :rtype: None
         """

--- a/src/mutils/animation.py
+++ b/src/mutils/animation.py
@@ -654,12 +654,12 @@ class Animation(mutils.Pose):
                 #Bookmarks stored in string values to be decoded later
                 #format = ({name}{start}{stop}{color r}{color b}{color c})
                 name = maya.cmds.getAttr(bookmark + ".name")
-                start = maya.cmds.getAttr(bookmark + ".timeRangeStart")
-                stop = maya.cmds.getAttr(bookmark + ".timeRangeStop")
+                bookmarkStart = maya.cmds.getAttr(bookmark + ".timeRangeStart")
+                bookmarkStop = maya.cmds.getAttr(bookmark + ".timeRangeStop")
                 colorR = maya.cmds.getAttr(bookmark + ".colorR")
                 colorG = maya.cmds.getAttr(bookmark + ".colorG")
                 colorB = maya.cmds.getAttr(bookmark + ".colorB")
-                bookmarkData = "{" + str(name) + "}" + "{" + str(start) + "}" + "{" + str(stop) + "}" + "{" + str(colorR) + "}" + "{" + str(colorG) + "}" + "{" + str(colorB) + "}"
+                bookmarkData = "{" + str(name) + "}" + "{" + str(bookmarkStart) + "}" + "{" + str(bookmarkStop) + "}" + "{" + str(colorR) + "}" + "{" + str(colorG) + "}" + "{" + str(colorB) + "}"
                 bookmarkSaves.append(str(bookmarkData))
                 print('baked a bookmark of name ' + name)
 
@@ -889,10 +889,21 @@ class Animation(mutils.Pose):
                     #format = ({name}{start}{stop}{color r}{color b}{color c})
                     split = re.findall('\{(.*?)\}', bookmark)
 
-                    startTime = float(split[1]) + dstTime[0]
-                    stopTime = float(split[2]) + dstTime[0]
+                    startTime = float(split[1]) + startFrame
+                    stopTime = float(split[2]) + startFrame
 
-                    timeSliderBookmark.createBookmark(name=split[0], start= startTime, stop= stopTime, color=(float(split[3]), float(split[4]) , float(split[5])))
+                    #timeSliderBookmark.createBookmark(name=split[0], start= startTime, stop= stopTime, color=(float(split[3]), float(split[4]) , float(split[5])))
+                    maya.cmds.pluginInfo("timeSliderBookmark", edit=True, writeRequires=True)
+                    createdBookmark = maya.cmds.createNode("timeSliderBookmark", ss=True)
+                    priority = timeSliderBookmark.getNextPriority()
+
+                    maya.cmds.setAttr(createdBookmark + ".priority", priority)
+                    maya.cmds.setAttr(createdBookmark + ".name", split[0], type="string")
+                    maya.cmds.setAttr(createdBookmark + ".timeRangeStart", startTime)
+                    maya.cmds.setAttr(createdBookmark + ".timeRangeStop", stopTime)
+                    maya.cmds.setAttr(createdBookmark + ".colorR", float(split[3]))
+                    maya.cmds.setAttr(createdBookmark + ".colorG", float(split[4]))
+                    maya.cmds.setAttr(createdBookmark + ".colorB", float(split[5]))
 
         finally:
             self.close()

--- a/src/mutils/animation.py
+++ b/src/mutils/animation.py
@@ -93,7 +93,7 @@ def saveAnim(
         iconPath="",
         sequencePath="",
         bakeConnected=True,
-        bakeBookmarks=False
+        bakeBookmarks=True
 ):
     """
     Save the anim data for the given objects.
@@ -449,9 +449,9 @@ class Animation(mutils.Pose):
     
     def bookmarks(self):
         """
-        Returns all associated bookmarks with anim
+        Returns all associated bookmarks with anim broken into string segements
 
-        :rtype: list timesliderbookmarks
+        :rtype: str[]
         """
         return self.metadata().get("bookmarks")
 
@@ -603,7 +603,7 @@ class Animation(mutils.Pose):
         sampleBy=1,
         fileType="",
         bakeConnected=True,
-        bakeBookmarks=False
+        bakeBookmarks=True
     ):
         """
         Save all animation data from the objects set on the Anim object.
@@ -664,6 +664,8 @@ class Animation(mutils.Pose):
                 print('baked a bookmark of name ' + name)
 
             self.setMetadata("bookmarks", bookmarkSaves)
+        else:
+            print('bookmark saving is disabled')
 
         self.setMetadata("endFrame", end)
         self.setMetadata("startFrame", start)

--- a/src/mutils/animation.py
+++ b/src/mutils/animation.py
@@ -21,6 +21,7 @@ import mutils.gui
 
 try:
     import maya.cmds
+    import maya.plugin.timeSliderBookmark.timeSliderBookmark as timeSliderBookmark
 except ImportError:
     import traceback
     traceback.print_exc()
@@ -309,6 +310,7 @@ def loadAnims(
     mirrorTable=None,
     currentTime=None,
     showDialog=False,
+    bookmarks=None
 ):
     """
     Load the animations in the given order of paths with the spacing specified.
@@ -373,6 +375,7 @@ def loadAnims(
             namespaces=namespaces,
             currentTime=currentTime,
             mirrorTable=mirrorTable,
+            bookmarks=bookmarks
         )
 
         duration = anim.endFrame() - anim.startFrame()
@@ -442,6 +445,14 @@ class Animation(mutils.Pose):
         :rtype: int
         """
         return self.metadata().get("endFrame")
+    
+    def bookmarks(self):
+        """
+        Returns all associated bookmarks with anim
+
+        :rtype: list timesliderbookmarks
+        """
+        return self.metadata().get("bookmarks")
 
     def mayaPath(self):
         """
@@ -634,6 +645,15 @@ class Animation(mutils.Pose):
         self.setMetadata("endFrame", end)
         self.setMetadata("startFrame", start)
 
+        
+        #if bakeBookmarks:
+        #Load bookmark plugin
+        maya.cmds.loadPlugin('timeSliderBookmark')
+        bookmarks = maya.cmds.ls(type="timeSliderBookmark")
+        print("baking bookmarks")
+        self.setMetadata("bookmarks", bookmarks)
+        #pass
+
         end += 1
         validCurves = []
         deleteObjects = []
@@ -728,7 +748,8 @@ class Animation(mutils.Pose):
             option=None,
             connect=False,
             mirrorTable=None,
-            currentTime=None
+            currentTime=None,
+            bookmarks=None
     ):
         """
         Load the animation data to the given objects or namespaces.
@@ -755,6 +776,15 @@ class Animation(mutils.Pose):
 
         if option is None or option == PasteOption.ReplaceAll:
             option = PasteOption.ReplaceCompletely
+
+        #load animation bookmarks
+        maya.cmds.loadPlugin('timeSliderBookmark')
+        bookmarks = self.bookmarks() or []
+
+        if bookmarks is not None:
+            for bookmark in bookmarks:
+                print("WE FOUND A BOOKMARK")
+                timeSliderBookmark.createBookmark(name=bookmark, start=10, stop=11, color=(1, 0 ,0))
 
         self.validate(namespaces=namespaces)
 

--- a/src/studiolibrarymaya/animitem.py
+++ b/src/studiolibrarymaya/animitem.py
@@ -91,6 +91,14 @@ class AnimItem(baseitem.BaseItem):
                 "label": {"name": ""}
             },
             {
+                "name": "testBool",
+                "type": "bool",
+                "inline": True,
+                "default": True,
+                "persistent": True,
+                "label": {"name": ""}
+            },
+            {
                 "name": "sourceTime",
                 "title": "source",
                 "type": "range",
@@ -193,6 +201,14 @@ class AnimItem(baseitem.BaseItem):
             },
             {
                 "name": "bakeConnected",
+                "type": "bool",
+                "default": False,
+                "persistent": True,
+                "inline": True,
+                "label": {"visible": False}
+            },
+            {
+                "name": "bakeBookmarks",
                 "type": "bool",
                 "default": False,
                 "persistent": True,

--- a/src/studiolibrarymaya/animitem.py
+++ b/src/studiolibrarymaya/animitem.py
@@ -91,14 +91,6 @@ class AnimItem(baseitem.BaseItem):
                 "label": {"name": ""}
             },
             {
-                "name": "testBool",
-                "type": "bool",
-                "inline": True,
-                "default": True,
-                "persistent": True,
-                "label": {"name": ""}
-            },
-            {
                 "name": "sourceTime",
                 "title": "source",
                 "type": "range",

--- a/src/studiolibrarymaya/animitem.py
+++ b/src/studiolibrarymaya/animitem.py
@@ -286,6 +286,7 @@ class AnimItem(baseitem.BaseItem):
             iconPath=kwargs.get("thumbnail"),
             metadata={"description": kwargs.get("comment", "")},
             sequencePath=sequencePath,
-            bakeConnected=kwargs.get("bakeConnected")
+            bakeConnected=kwargs.get("bakeConnected"),
+            bakeBookmarks=kwargs.get("bakeBookmarks")
             #get the bookmark bool
         )

--- a/src/studiolibrarymaya/animitem.py
+++ b/src/studiolibrarymaya/animitem.py
@@ -131,7 +131,8 @@ class AnimItem(baseitem.BaseItem):
             option=kwargs.get("option"),
             connect=kwargs.get("connect"),
             mirrorTable=kwargs.get("mirrorTable"),
-            currentTime=kwargs.get("currentTime")
+            currentTime=kwargs.get("currentTime"),
+            bookmarks=kwargs.get("bookmarks")
         )
 
     def saveSchema(self):

--- a/src/studiolibrarymaya/animitem.py
+++ b/src/studiolibrarymaya/animitem.py
@@ -286,4 +286,5 @@ class AnimItem(baseitem.BaseItem):
             metadata={"description": kwargs.get("comment", "")},
             sequencePath=sequencePath,
             bakeConnected=kwargs.get("bakeConnected")
+            #get the bookmark bool
         )


### PR DESCRIPTION
At the studio I work for, we had a special need to save and load bookmarks alongside our animations in studio library, this branch adds that functionality by using mutlis' meta data saving system. It adds a new key value pair in the meta data for a list of bookmarks that is then loaded when an animation is brought in. The data inside of the meta data is formatted in one long string containing the name of the bookmark, the start frame, the stop frame, and the color. Comments are included in the code that outline how that string is formatted.

Wanted to request a pull into the main branch, should you want to include this feature, in the hopes that we might be able to continue to receive new updates without backporting this feature but if not I do understand considering this is a pretty specific feature. Please let me know if there's any formatting or structural changes that would have to happen.

Thank you in advance, and have a great day!