### PR TITLE
Added support for proxy attributes save/load

### DIFF
--- a/src/mutils/animation.py
+++ b/src/mutils/animation.py
@@ -657,7 +657,6 @@ class Animation(mutils.Pose):
                     for proxy in proxyAttrs:
                         logger.debug("proxy attribute: %s", proxy)
                         proxy.unProxy()
-                    # mutils.Attribute.deleteProxyAttrs(dstNode)
                     maya.cmds.pasteKey(dstNode)
 
                     attrs = maya.cmds.listAttr(dstNode, unlocked=True, keyable=True) or []

--- a/src/mutils/animation.py
+++ b/src/mutils/animation.py
@@ -817,10 +817,6 @@ class Animation(mutils.Pose):
                         logger.debug('Skipping attribute: The destination attribute "%s" does not exist!' % dstAttr.fullname())
                         continue
 
-                    # if dstAttr.isProxy():
-                    #     logger.debug('Skipping attribute: The destination attribute "%s" is a proxy attribute!', dstAttr.fullname())
-                    #     continue
-
                     srcCurve = self.animCurve(srcNode.name(), attr, withNamespace=True)
 
                     if srcCurve:

--- a/src/mutils/attribute.py
+++ b/src/mutils/attribute.py
@@ -193,15 +193,20 @@ class Attribute(object):
 
         :rtype: None
         """
+        # Collect all the data before deleting the attribute, as that will require it to
+        # still be alive.
+        name = self.attr()
+        type_ = self.type()
+        value = self.value()
         if self.isProxy():
             self.delete()
         # Re-create the attribute in non-proxy mode.
         maya.cmds.addAttr(
             self.name(),
-            longName=self.attr(),
-            attributeType=self.type(),
-            defaultValue=self.value(),
-            keyable=True,  # TODO make sure this is not stupid, but it shouldn't
+            longName=name,
+            attributeType=type_,
+            defaultValue=value,
+            keyable=True,
         )
 
     def delete(self):

--- a/src/mutils/attribute.py
+++ b/src/mutils/attribute.py
@@ -516,6 +516,9 @@ class Attribute(object):
 
         if self.exists():
 
+            # Find the keys connected to the current attribute. If the attribute is a proxy, the anim keys will
+            # actually be connected to the node where the source of the proxy attribute comes from, so traverse
+            # that to find the keys.
             animSource = self.fullname()
             if self.isProxy():
                 animSource = self.listConnections(plugs=True, destination=False)

--- a/src/mutils/attribute.py
+++ b/src/mutils/attribute.py
@@ -449,10 +449,6 @@ class Attribute(object):
         fullname = self.fullname()
         startTime, endTime = time
 
-        # if self.isProxy():
-        #     logger.debug("Cannot set anim curve for proxy attribute")
-        #     return
-
         if not self.exists():
             logger.debug("Attr does not exists")
             return


### PR DESCRIPTION
Provides support for proxy attributes by converting them back to dynamic attributes before their keys are exported, as before they were just getting deleted, and the keys never saved.