### PR TITLE
py2 fix for unproxyAttrs

### DIFF
--- a/src/mutils/animation.py
+++ b/src/mutils/animation.py
@@ -299,7 +299,7 @@ def unproxyAttrs(node):
 
     for attr in maya.cmds.listAttr(node, unlocked=True, keyable=True, userDefined=True) or []:
 
-        plug = f"{node}.{attr}"
+        plug = "{0}.{1}".format(node, attr)
         proxy = maya.cmds.addAttr(plug, q=True, usedAsProxy=True)
 
         if not proxy:


### PR DESCRIPTION
This change removes the use of f-strings in [mutils.animation.unproxyAttrs:302](https://github.com/krathjen/studiolibrary/blob/402586d623097417f6e1f0e7d5774b3e21972058/src/mutils/animation.py#L302)  as it causes a breaking change in Maya 2021 and below.

fixes: https://github.com/krathjen/studiolibrary/issues/502